### PR TITLE
Add DPO email & privacy URL to identity endpoint

### DIFF
--- a/paf-mvp-core-js/src/express/identity-endpoint.ts
+++ b/paf-mvp-core-js/src/express/identity-endpoint.ts
@@ -5,8 +5,15 @@ import cors from 'cors';
 import { Express } from 'express';
 import { GetIdentityResponseBuilder } from '@core/model/identity-response-builder';
 
-export const addIdentityEndpoint = (app: Express, name: string, type: 'vendor' | 'operator', keys: KeyInfo[]) => {
-  const response = new GetIdentityResponseBuilder(name, type).buildResponse(keys);
+export const addIdentityEndpoint = (
+  app: Express,
+  name: string,
+  type: 'vendor' | 'operator',
+  keys: KeyInfo[],
+  dpoEmailAddress: string,
+  privacyPolicyUrl: URL
+) => {
+  const response = new GetIdentityResponseBuilder(name, type, dpoEmailAddress, privacyPolicyUrl).buildResponse(keys);
 
   app.get(participantEndpoints.identity, cors(corsOptionsAcceptAll), (req, res) => {
     res.send(response);

--- a/paf-mvp-core-js/src/model/generated-model.ts
+++ b/paf-mvp-core-js/src/model/generated-model.ts
@@ -171,6 +171,14 @@ export interface GetIdentityResponse {
   type: 'vendor' | 'operator';
   version: Version;
   /**
+   * Email address to contact the company
+   */
+  dpo_email: string;
+  /**
+   * URL of the recipient's privacy policy
+   */
+  privacy_policy_url: string;
+  /**
    * List of public keys the contracting party used or is using for signing data and messages
    */
   keys: {

--- a/paf-mvp-core-js/src/model/identity-response-builder.ts
+++ b/paf-mvp-core-js/src/model/identity-response-builder.ts
@@ -2,10 +2,17 @@ import { KeyInfo } from '@core/crypto/identity';
 import { GetIdentityResponse } from '@core/model/generated-model';
 
 export class GetIdentityResponseBuilder {
-  constructor(protected name: string, protected type: 'vendor' | 'operator') {}
+  constructor(
+    protected name: string,
+    protected type: 'vendor' | 'operator',
+    protected dpoEmailAddress: string,
+    protected privacyPolicyUrl: URL
+  ) {}
 
   buildResponse(keys: KeyInfo[]): GetIdentityResponse {
     return {
+      dpo_email: this.dpoEmailAddress,
+      privacy_policy_url: this.privacyPolicyUrl.toString(),
       name: this.name,
       keys: keys.map(({ startTimestampInSec, endTimestampInSec, publicKey }: KeyInfo) => ({
         key: publicKey,

--- a/paf-mvp-core-js/tests/test-cases/key-store.test.ts
+++ b/paf-mvp-core-js/tests/test-cases/key-store.test.ts
@@ -46,6 +46,8 @@ h4/WfMRMVh3HIqojt3LIsvUQig1rm9ZkcNx+IHZVhDM+hso2sXlGjF9xOQ==
       type: 'vendor',
       name: 'My domain',
       keys: [oldKey, currentKey],
+      privacy_policy_url: 'https://mockPolicy.com',
+      dpo_email: 'mock@vendor.com',
     };
 
     const keyStore = new PublicKeyStore({}, axios.create({}));
@@ -80,6 +82,8 @@ h4/WfMRMVh3HIqojt3LIsvUQig1rm9ZkcNx+IHZVhDM+hso2sXlGjF9xOQ==
           end: undefined, // No end date
         },
       ],
+      privacy_policy_url: 'https://mockPolicy.com',
+      dpo_email: 'mock@vendor.com',
     };
 
     const keyStore = new PublicKeyStore({});
@@ -107,6 +111,8 @@ h4/WfMRMVh3HIqojt3LIsvUQig1rm9ZkcNx+IHZVhDM+hso2sXlGjF9xOQ==
       type: 'vendor',
       name: 'My domain',
       keys: [oldKey, currentKey],
+      privacy_policy_url: 'https://mockPolicy.com',
+      dpo_email: 'mock@vendor.com',
     };
 
     // Provide mock timer
@@ -146,6 +152,8 @@ h4/WfMRMVh3HIqojt3LIsvUQig1rm9ZkcNx+IHZVhDM+hso2sXlGjF9xOQ==
       type: 'vendor',
       name: 'My domain',
       keys: [oldKey],
+      privacy_policy_url: 'https://mockPolicy.com',
+      dpo_email: 'mock@vendor.com',
     };
 
     const keyStore = new PublicKeyStore({});

--- a/paf-mvp-demo-express/scripts/generate-examples.ts
+++ b/paf-mvp-demo-express/scripts/generate-examples.ts
@@ -362,7 +362,9 @@ class Examples {
     const getIdentityRequestBuilder_operator = new GetIdentityRequestBuilder(crtoOneOperatorConfig.host);
     const getIdentityResponseBuilder_operator = new GetIdentityResponseBuilder(
       crtoOneOperatorConfig.name,
-      operatorPrivateConfig.type
+      operatorPrivateConfig.type,
+      operatorPrivateConfig.dpoEmailAddress,
+      new URL(operatorPrivateConfig.privacyPolicyUrl)
     );
     this.getIdentityRequest_operatorHttp = getGETUrl(getIdentityRequestBuilder_operator.getRestUrl(undefined));
     this.getIdentityResponse_operatorJson = getIdentityResponseBuilder_operator.buildResponse([
@@ -371,7 +373,12 @@ class Examples {
 
     // TODO add examples with multiple keys
     const getIdentityRequestBuilder_cmp = new GetIdentityRequestBuilder(pafCmpConfig.host);
-    const getIdentityResponseBuilder_cmp = new GetIdentityResponseBuilder(pafCmpConfig.name, pafCmpPrivateConfig.type);
+    const getIdentityResponseBuilder_cmp = new GetIdentityResponseBuilder(
+      pafCmpConfig.name,
+      pafCmpPrivateConfig.type,
+      pafCmpPrivateConfig.dpoEmailAddress,
+      new URL(pafCmpPrivateConfig.privacyPolicyUrl)
+    );
     this.getIdentityRequest_cmpHttp = getGETUrl(getIdentityRequestBuilder_cmp.getRestUrl(undefined));
     this.getIdentityResponse_cmpJson = getIdentityResponseBuilder_cmp.buildResponse([
       pafCmpPrivateConfig.currentPublicKey,

--- a/paf-mvp-demo-express/src/config.ts
+++ b/paf-mvp-demo-express/src/config.ts
@@ -10,6 +10,8 @@ export interface PrivateConfig {
   currentPublicKey: KeyInfo;
   privateKey: string;
   type: 'vendor' | 'operator'; // TODO should support more
+  dpoEmailAddress: string;
+  privacyPolicyUrl: string;
 }
 
 export const pafMarketConfig: PublicConfig = {

--- a/paf-mvp-demo-express/src/crto1-operator.ts
+++ b/paf-mvp-demo-express/src/crto1-operator.ts
@@ -30,6 +30,8 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgxK7RQm5KP1g62SQn
 oyeE+rrDPJzpZxIyCCTHDvd1TRShRANCAAQSJkhGEbE118biXou5jZB+PJ/rRHSO
 ZxbtbfH3C+VfhheolRApHZzSW96pUOPiHA7SRNkO41FSGDGTiKvBXd/P
 -----END PRIVATE KEY-----`,
+  dpoEmailAddress: 'contact@crto-poc-1.onekey.network',
+  privacyPolicyUrl: 'https://crto-poc-1.onekey.network/privacy',
 };
 
 export const crtoOneOperatorApp = express();
@@ -50,5 +52,7 @@ addOperatorApi(
     [pifMarketConfig.host]: [Permission.READ, Permission.WRITE],
     [pofMarketConfig.host]: [Permission.READ, Permission.WRITE],
   },
+  operatorPrivateConfig.dpoEmailAddress,
+  new URL(operatorPrivateConfig.privacyPolicyUrl),
   s2sOptions
 );

--- a/paf-mvp-demo-express/src/paf-cmp.ts
+++ b/paf-mvp-demo-express/src/paf-cmp.ts
@@ -21,6 +21,8 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg0X8r0PYAm3mq206o
 CdMHwZ948ONyVJToeFbLqBDKi7OhRANCAASXTbvyly6lrFR+Kocn0Ab2BUzIg76f
 Ts8lo0jba/6zuFHUeRvvUN7o63lngkuhntqPXFiEVxAmxiQWVfFwFZ9F
 -----END PRIVATE KEY-----`,
+  dpoEmailAddress: 'contact@www.pafdemopublisher.com',
+  privacyPolicyUrl: 'https://www.pafdemopublisher.com/privacy',
 };
 
 export const pafCmpApp = express();
@@ -38,4 +40,11 @@ addOperatorClientProxyEndpoints(
 );
 
 // Add identity endpoint
-addIdentityEndpoint(pafCmpApp, pafCmpConfig.name, pafCmpPrivateConfig.type, [pafCmpPrivateConfig.currentPublicKey]);
+addIdentityEndpoint(
+  pafCmpApp,
+  pafCmpConfig.name,
+  pafCmpPrivateConfig.type,
+  [pafCmpPrivateConfig.currentPublicKey],
+  pafCmpPrivateConfig.dpoEmailAddress,
+  new URL(pafCmpPrivateConfig.privacyPolicyUrl)
+);

--- a/paf-mvp-demo-express/src/paf-market.ts
+++ b/paf-mvp-demo-express/src/paf-market.ts
@@ -22,6 +22,8 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgxrHgVC3uFlEqnqab
 cPqLNBFbMbt1tAPsvKy8DBV2m+ChRANCAARSdqvCnSBRmCNv1+xg0tw2t100pXmH
 j9Z8xExWHcciqiO3csiy9RCKDWub1mRw3H4gdlWEMz6GyjaxeUaMX3E5
 -----END PRIVATE KEY-----`,
+  dpoEmailAddress: 'contact@www.pafmarket.shop',
+  privacyPolicyUrl: 'https://www.pafmarket.shop/privacy',
 };
 
 export const pafMarketApp = express();
@@ -58,6 +60,11 @@ addOperatorClientProxyEndpoints(
 );
 
 // Add identity endpoint
-addIdentityEndpoint(pafMarketApp, pafMarketConfig.name, pafMarketPrivateConfig.type, [
-  pafMarketPrivateConfig.currentPublicKey,
-]);
+addIdentityEndpoint(
+  pafMarketApp,
+  pafMarketConfig.name,
+  pafMarketPrivateConfig.type,
+  [pafMarketPrivateConfig.currentPublicKey],
+  pafMarketPrivateConfig.dpoEmailAddress,
+  new URL(pafMarketPrivateConfig.privacyPolicyUrl)
+);

--- a/paf-mvp-demo-express/src/pif-cmp.ts
+++ b/paf-mvp-demo-express/src/pif-cmp.ts
@@ -20,6 +20,8 @@ MHcCAQEEIF4OKHOcZh3/XeLmP5yPtb0qiBc+8vuZf0bgVrOo/CbIoAoGCCqGSM49
 AwEHoUQDQgAEKwW/bVmi/yM2QRtPMKGeKMylxBBgQs9+mjSaivSEXR8VCCJfxdkt
 JyDD+ooj5HxZibrLkmoQ8klbnMaXBvkVkw==
 -----END EC PRIVATE KEY-----`,
+  dpoEmailAddress: 'contact@www.pifdemopublisher.com',
+  privacyPolicyUrl: 'https://www.pifdemopublisher.com/privacy',
 };
 
 export const pifCmpApp = express();
@@ -37,4 +39,11 @@ addOperatorClientProxyEndpoints(
 );
 
 // Add identity endpoint
-addIdentityEndpoint(pifCmpApp, pifCmpConfig.name, pifCmpPrivateConfig.type, [pifCmpPrivateConfig.currentPublicKey]);
+addIdentityEndpoint(
+  pifCmpApp,
+  pifCmpConfig.name,
+  pifCmpPrivateConfig.type,
+  [pifCmpPrivateConfig.currentPublicKey],
+  pifCmpPrivateConfig.dpoEmailAddress,
+  new URL(pifCmpPrivateConfig.privacyPolicyUrl)
+);

--- a/paf-mvp-demo-express/src/pif-market.ts
+++ b/paf-mvp-demo-express/src/pif-market.ts
@@ -20,6 +20,8 @@ MHcCAQEEIHdDU+4DGYLAqroSuXm3yMyd0fN3KHV+dS/14F9qOIRSoAoGCCqGSM49
 AwEHoUQDQgAEEaF2LzzUF4lEQ4KQZxVkz7Sl5KIw0Pk2uD/k+nv9NnSZat9kQtJ8
 MfRbBTyw+3s7boL9UFmkpc366R8fFXZMjg==
 -----END EC PRIVATE KEY-----`,
+  dpoEmailAddress: 'contact@www.pifmarket.shop',
+  privacyPolicyUrl: 'https://www.pifmarket.shop/privacy',
 };
 
 export const pifMarketApp = express();
@@ -45,6 +47,11 @@ addOperatorClientProxyEndpoints(
 );
 
 // Add identity endpoint
-addIdentityEndpoint(pifMarketApp, pifMarketConfig.name, pifMarketPrivateConfig.type, [
-  pifMarketPrivateConfig.currentPublicKey,
-]);
+addIdentityEndpoint(
+  pifMarketApp,
+  pifMarketConfig.name,
+  pifMarketPrivateConfig.type,
+  [pifMarketPrivateConfig.currentPublicKey],
+  pifMarketPrivateConfig.dpoEmailAddress,
+  new URL(pifMarketPrivateConfig.privacyPolicyUrl)
+);

--- a/paf-mvp-demo-express/src/pof-cmp.ts
+++ b/paf-mvp-demo-express/src/pof-cmp.ts
@@ -20,6 +20,8 @@ MHcCAQEEIIodhppYa0SJtSzEKntZM5Dr0xh/5xcbk9QRzqvmp1eEoAoGCCqGSM49
 AwEHoUQDQgAE1CAIeic0n0aSLczizA1xzhxDPRBDEoKX2OO3IeuyAyVAOmcb9Rab
 k/MRohFL/ay2XJUUf7Jb9weRJH9CuSEYZQ==
 -----END EC PRIVATE KEY-----`,
+  dpoEmailAddress: 'contact@www.pofdemopublisher.com',
+  privacyPolicyUrl: 'https://www.pofdemopublisher.com/privacy',
 };
 
 export const pofCmpApp = express();
@@ -37,4 +39,11 @@ addOperatorClientProxyEndpoints(
 );
 
 // Add identity endpoint
-addIdentityEndpoint(pofCmpApp, pofCmpConfig.name, pofCmpPrivateConfig.type, [pofCmpPrivateConfig.currentPublicKey]);
+addIdentityEndpoint(
+  pofCmpApp,
+  pofCmpConfig.name,
+  pofCmpPrivateConfig.type,
+  [pofCmpPrivateConfig.currentPublicKey],
+  pofCmpPrivateConfig.dpoEmailAddress,
+  new URL(pofCmpPrivateConfig.privacyPolicyUrl)
+);

--- a/paf-mvp-demo-express/src/pof-market.ts
+++ b/paf-mvp-demo-express/src/pof-market.ts
@@ -20,6 +20,8 @@ MHcCAQEEINYQ3rZ6+TUBN1IYOE1jpfFXGIjl1kDfFxy4AqqvYpFzoAoGCCqGSM49
 AwEHoUQDQgAETKe8WSDJmxoVWLgHk3F2Q0vtewqncNqOUrKuGEU+7iwJPiQVkdL1
 hshouUEPI2C2ti8j0s3K3JY2imY3DxKigw==
 -----END EC PRIVATE KEY-----`,
+  dpoEmailAddress: 'contact@www.pofmarket.shop',
+  privacyPolicyUrl: 'https://www.pofmarket.shop/privacy',
 };
 
 export const pofMarketApp = express();
@@ -45,6 +47,11 @@ addOperatorClientProxyEndpoints(
 );
 
 // Add identity endpoint
-addIdentityEndpoint(pofMarketApp, pofMarketConfig.name, pofMarketPrivateConfig.type, [
-  pofMarketPrivateConfig.currentPublicKey,
-]);
+addIdentityEndpoint(
+  pofMarketApp,
+  pofMarketConfig.name,
+  pofMarketPrivateConfig.type,
+  [pofMarketPrivateConfig.currentPublicKey],
+  pofMarketPrivateConfig.dpoEmailAddress,
+  new URL(pofMarketPrivateConfig.privacyPolicyUrl)
+);

--- a/paf-mvp-demo-express/src/portal.ts
+++ b/paf-mvp-demo-express/src/portal.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { crtoOneOperatorConfig, portalConfig, PrivateConfig } from './config';
+import { crtoOneOperatorConfig, pofMarketConfig, portalConfig, PrivateConfig } from './config';
 import { OperatorClient } from '@operator-client/operator-client';
 import { Cookies, fromIdsCookie, fromPrefsCookie } from '@core/cookies';
 import {
@@ -30,6 +30,7 @@ import { IdsAndPreferencesVerifier, MessageVerifier, Verifier } from '@core/cryp
 import { UnsignedMessage } from '@core/model/model';
 import { jsonOperatorEndpoints, redirectEndpoints } from '@core/endpoints';
 import { getTimeStampInSec } from '@core/timestamp';
+import { pofMarketApp } from './pof-market';
 
 const portalPrivateConfig: PrivateConfig = {
   type: 'vendor',
@@ -46,6 +47,8 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgiDfb74JY+vBjdEmr
 hScLNr4U4Wrp4dKKMm0Z/+h3OnahRANCAARqwDtVwGtTx+zY/5njGZxnxuGePdAq
 7fKlkuHOKtwM/AJ6oBTJ7+l3rY5ffNJZkVBB3Pt9H3cHO3Bztmh1h7xR
 -----END PRIVATE KEY-----`,
+  dpoEmailAddress: 'contact@portal.onekey.network',
+  privacyPolicyUrl: 'https://portal.onekey.network/privacy',
 };
 export const portalApp = express();
 
@@ -283,4 +286,11 @@ portalApp.get('/', (req, res) => {
   res.render('portal/index', options);
 });
 
-addIdentityEndpoint(portalApp, portalConfig.name, 'vendor', [portalPrivateConfig.currentPublicKey]);
+addIdentityEndpoint(
+  portalApp,
+  portalConfig.name,
+  portalPrivateConfig.type,
+  [portalPrivateConfig.currentPublicKey],
+  portalPrivateConfig.dpoEmailAddress,
+  new URL(portalPrivateConfig.privacyPolicyUrl)
+);

--- a/paf-mvp-operator-express/src/operator-api.ts
+++ b/paf-mvp-operator-express/src/operator-api.ts
@@ -70,12 +70,14 @@ export const addOperatorApi = (
   name: string,
   keys: KeyInfo[],
   allowedDomains: AllowedDomains,
+  dpoEmailAddress: string,
+  privacyPolicyUrl: URL,
   s2sOptions?: AxiosRequestConfig
 ) => {
   const keyStore = new PublicKeyStore(s2sOptions);
 
   // Start by adding identity endpoint
-  addIdentityEndpoint(app, name, 'operator', keys);
+  addIdentityEndpoint(app, name, 'operator', keys, dpoEmailAddress, privacyPolicyUrl);
 
   const getIdsPrefsResponseBuilder = new GetIdsPrefsResponseBuilder(operatorHost, privateKey);
   const get3PCResponseBuilder = new Get3PCResponseBuilder();


### PR DESCRIPTION
Note that the privacy urls are not reachable. We might want to update the demo to expose `/privacy` dummy pages.