### PR TITLE
Fix notification on pafmarket.shop

### DIFF
--- a/paf-mvp-demo-express/src/paf-market.ts
+++ b/paf-mvp-demo-express/src/paf-market.ts
@@ -40,13 +40,14 @@ pafMarketApp.get('/', async (req: Request, res: Response) => {
   const view = 'advertiser/index';
 
   // Act as an HTTP middleware
-  if (await client.getIdsAndPreferencesOrRedirect(req, res, view)) {
-    res.render(view, {
-      title: pafMarketConfig.name,
-      proxyHostName: pafMarketConfig.host,
-      cdnHost: pafMarketConfig.cdnHost,
-    });
-  }
+  // FIXME the usage of the backend client breaks logic for showing the notification. Need to decide how to fix.
+  //if (await client.getIdsAndPreferencesOrRedirect(req, res, view)) {
+  res.render(view, {
+    title: pafMarketConfig.name,
+    proxyHostName: pafMarketConfig.host,
+    cdnHost: pafMarketConfig.cdnHost,
+  });
+  //}
 });
 
 // ...and also as a JS proxy

--- a/paf-mvp-demo-express/src/views/publisher/index.hbs
+++ b/paf-mvp-demo-express/src/views/publisher/index.hbs
@@ -146,7 +146,7 @@
     {{/if}}
 </head>
 <body>
-<script src="https://{{cdnDomain}}/assets/app.bundle.js" data-proxy="{{proxyHostName}}"></script>
+<script src="https://{{cdnDomain}}/assets/app.bundle.js" data-proxy="{{proxyHostName}}" onload='PAF.refreshIdsAndPreferences({ proxyHostName: "{{proxyHostName}}" });'></script>
 
 <div>
     <link href="https://fonts.googleapis.com/css?family=Muli:300,400,500,600,700,800,900&display=swap" rel="stylesheet">

--- a/paf-mvp-frontend/rollup.config.js
+++ b/paf-mvp-frontend/rollup.config.js
@@ -22,6 +22,32 @@ const getDestFolder = (path) => (DEV ? DIST : relative('../paf-mvp-demo-express/
 // https://rollupjs.org/guide/en/#configuration-files
 export default [
   defineConfig({
+    input: relative('src/lib/paf-lib.ts'),
+    output: {
+      file: getDestFolder(`/paf-lib.js`),
+      format: 'umd',
+      name: 'PAF',
+      sourcemap: DEV
+    },
+    treeshake: 'smallest', // remove unused code
+    plugins: [
+      typescript({
+        tsconfig: relative('../tsconfig.json')
+      }),
+      commonjs(),
+      nodeResolve(),
+      ...(() => {
+        if (DEV) {
+          return []
+        } else {
+          return [
+            terser(), // minify js output
+          ]
+        }
+      })(),
+    ]
+  }),
+  defineConfig({
     input: relative('src/main.ts'), // entry file
     output: {
       file: getDestFolder(`/app.bundle.js`),

--- a/paf-mvp-frontend/src/lib/paf-lib.ts
+++ b/paf-mvp-frontend/src/lib/paf-lib.ts
@@ -298,11 +298,8 @@ export const refreshIdsAndPreferences = async (options: RefreshIdsAndPrefsOption
     const currentlySelectedConsent = currentPafData.preferences?.data?.use_browsing_for_personalization;
 
     const triggerNotification = (freshConsent: boolean) => {
-      const shouldShowNotification =
-        !strPreferences || // there was no value before the refresh
-        freshConsent !== currentlySelectedConsent; // the new value is different from the previous one
-
-      if (shouldShowNotification) {
+      // the new value is different from the previous one
+      if (freshConsent !== currentlySelectedConsent) {
         logDebug(`Preferences changes detected (${currentlySelectedConsent} => ${freshConsent}), show notification`);
         showNotificationIfValid(freshConsent);
       } else {

--- a/paf-mvp-frontend/src/main.ts
+++ b/paf-mvp-frontend/src/main.ts
@@ -4,7 +4,13 @@ import { PromptConsent } from './widgets/prompt-consent';
 import { notificationService } from './services/notification.service';
 import { NotificationEnum } from '@frontend/enums/notification.enum';
 import { currentScript } from '@frontend/utils/current-script';
-import { refreshIdsAndPreferences } from './lib/paf-lib';
+import {
+  getIdsAndPreferences,
+  getNewId,
+  refreshIdsAndPreferences,
+  signPreferences,
+  updateIdsAndPreferences,
+} from './lib/paf-lib';
 
 currentScript.setScript(document.currentScript as HTMLScriptElement);
 
@@ -13,4 +19,4 @@ const showNotification = (type: NotificationEnum) => notificationService.showNot
 
 // TODO: avoid global declaration
 window.PAFUI ??= { promptConsent, showNotification };
-refreshIdsAndPreferences({ proxyHostName: currentScript.getData().proxy });
+window.PAF ??= { getNewId, signPreferences, getIdsAndPreferences, refreshIdsAndPreferences, updateIdsAndPreferences };


### PR DESCRIPTION
- Fix double refresh on advertisers
- Put back paf-lib.ts compilation with rollup
- Fix error on "marketing preferences" link ("PAF is not defined")

Note: the fix implies to unactivate hte "operator backend client" middleware on pafmarket.shop.
Will need to decide what to do with this component (kill it?)