### PR TITLE
Disable log in tests

### DIFF
--- a/paf-mvp-core-js/src/log.ts
+++ b/paf-mvp-core-js/src/log.ts
@@ -1,6 +1,15 @@
+enum LogLevel {
+  None = 1,
+  Debug,
+  Message,
+  Info,
+  Warn,
+  Error,
+}
+
 // Wrappers to console.(log | info | warn | error). Takes N arguments, the same as the native methods
 export class Log {
-  public static enable = !this.isInJestEnvironment();
+  public static level = this.isInJestEnvironment() ? LogLevel.None : LogLevel.Error;
 
   private static isInJestEnvironment(): boolean {
     return typeof process === 'object' && process.env !== undefined && process.env.JEST_WORKER_ID !== undefined;
@@ -15,35 +24,35 @@ export class Log {
   }
 
   public Debug(...args: unknown[]) {
-    if (!Log.enable) {
+    if (Log.level <= LogLevel.Debug) {
       return;
     }
     console.log(...this.decorateLog('DEBUG:', args));
   }
 
   public Message(...args: unknown[]) {
-    if (!Log.enable) {
+    if (Log.level <= LogLevel.Message) {
       return;
     }
     console.log(...this.decorateLog('MESSAGE:', args));
   }
 
   public Info(...args: unknown[]) {
-    if (!Log.enable) {
+    if (Log.level <= LogLevel.Info) {
       return;
     }
     console.info(...this.decorateLog('INFO:', args));
   }
 
   public Warn(...args: unknown[]) {
-    if (!Log.enable) {
+    if (Log.level <= LogLevel.Warn) {
       return;
     }
     console.warn(...this.decorateLog('WARNING:', args));
   }
 
   public Error(...args: unknown[]) {
-    if (!Log.enable) {
+    if (Log.level <= LogLevel.Error) {
       return;
     }
     console.error(...this.decorateLog('ERROR:', args));

--- a/paf-mvp-core-js/src/log.ts
+++ b/paf-mvp-core-js/src/log.ts
@@ -24,35 +24,35 @@ export class Log {
   }
 
   public Debug(...args: unknown[]) {
-    if (Log.level <= LogLevel.Debug) {
+    if (Log.level < LogLevel.Debug) {
       return;
     }
     console.log(...this.decorateLog('DEBUG:', args));
   }
 
   public Message(...args: unknown[]) {
-    if (Log.level <= LogLevel.Message) {
+    if (Log.level < LogLevel.Message) {
       return;
     }
     console.log(...this.decorateLog('MESSAGE:', args));
   }
 
   public Info(...args: unknown[]) {
-    if (Log.level <= LogLevel.Info) {
+    if (Log.level < LogLevel.Info) {
       return;
     }
     console.info(...this.decorateLog('INFO:', args));
   }
 
   public Warn(...args: unknown[]) {
-    if (Log.level <= LogLevel.Warn) {
+    if (Log.level < LogLevel.Warn) {
       return;
     }
     console.warn(...this.decorateLog('WARNING:', args));
   }
 
   public Error(...args: unknown[]) {
-    if (Log.level <= LogLevel.Error) {
+    if (Log.level < LogLevel.Error) {
       return;
     }
     console.error(...this.decorateLog('ERROR:', args));

--- a/paf-mvp-core-js/src/log.ts
+++ b/paf-mvp-core-js/src/log.ts
@@ -1,9 +1,9 @@
 // Wrappers to console.(log | info | warn | error). Takes N arguments, the same as the native methods
 export class Log {
-  public static enable = !this.isInTestEnvironment();
+  public static enable = !this.isInJestEnvironment();
 
-  private static isInTestEnvironment(): boolean {
-    return process.env.JEST_WORKER_ID !== undefined;
+  private static isInJestEnvironment(): boolean {
+    return typeof process === 'object' && process.env !== undefined && process.env.JEST_WORKER_ID !== undefined;
   }
 
   private readonly id: string;

--- a/paf-mvp-core-js/src/log.ts
+++ b/paf-mvp-core-js/src/log.ts
@@ -1,5 +1,11 @@
 // Wrappers to console.(log | info | warn | error). Takes N arguments, the same as the native methods
 export class Log {
+  public static enable = !this.isInTestEnvironment();
+
+  private static isInTestEnvironment(): boolean {
+    return process.env.JEST_WORKER_ID !== undefined;
+  }
+
   private readonly id: string;
   private readonly color: string;
 
@@ -9,22 +15,37 @@ export class Log {
   }
 
   public Debug(...args: unknown[]) {
+    if (!Log.enable) {
+      return;
+    }
     console.log(...this.decorateLog('DEBUG:', args));
   }
 
   public Message(...args: unknown[]) {
+    if (!Log.enable) {
+      return;
+    }
     console.log(...this.decorateLog('MESSAGE:', args));
   }
 
   public Info(...args: unknown[]) {
+    if (!Log.enable) {
+      return;
+    }
     console.info(...this.decorateLog('INFO:', args));
   }
 
   public Warn(...args: unknown[]) {
+    if (!Log.enable) {
+      return;
+    }
     console.warn(...this.decorateLog('WARNING:', args));
   }
 
   public Error(...args: unknown[]) {
+    if (!Log.enable) {
+      return;
+    }
     console.error(...this.decorateLog('ERROR:', args));
   }
 


### PR DESCRIPTION
The simplest solution for removing the flood in the test console.

To be discussed if it is relevant. I am not 100% convinced. On one side, it is sometimes good to have all the logs on the CI to quickly pinpoint our issues. On the other side:
- with Jest, we don't know exactly what tests emits the logs so it is not really helpful,
- having many logs flood the console and it is not easy to iterate quickly on tests,
- seeing red log stating ERROR in the console of tests can be confusing.

