### PR TITLE
Improve import of Window

### DIFF
--- a/paf-mvp-audit/src/controller.ts
+++ b/paf-mvp-audit/src/controller.ts
@@ -6,6 +6,7 @@ import { View } from './view';
 import { BindingViewOnly } from '@core/ui/binding';
 import providerComponent from './html/components/provider.html';
 import iconTick from './images/IconTick.svg';
+import { Window } from '@frontend/global';
 
 // TODO: Add back when full audit information is available.
 // import iconCross from './images/iconCross.svg';
@@ -97,7 +98,7 @@ export class Controller {
       case 'settings':
         this.view.display('button');
         this.bindActions();
-        window.PAFUI.promptConsent();
+        (<Window>window).PAFUI.promptConsent();
         break;
       case 'audit':
         this.view.display('audit');

--- a/paf-mvp-frontend/src/containers/notification/Notification.tsx
+++ b/paf-mvp-frontend/src/containers/notification/Notification.tsx
@@ -5,6 +5,7 @@ import { ISnackBarProps, SnackBar } from '../../components/snack-bar/SnackBar';
 import { useEffect } from 'react';
 import { NotificationEnum } from '../../enums/notification.enum';
 import { useRef } from 'preact/hooks';
+import { Window } from '@frontend/global';
 
 export interface INotificationProps {
   type: NotificationEnum;
@@ -23,7 +24,7 @@ export const Notification = ({ type, destroy }: INotificationProps) => {
 
   const launchPrompt = (event: MouseEvent) => {
     event.preventDefault();
-    window.PAFUI.promptConsent();
+    (window as Window).PAFUI.promptConsent();
     window.clearTimeout(timerRef.current);
     destroy();
   };

--- a/paf-mvp-frontend/src/containers/welcome-widget/WelcomeWidget.tsx
+++ b/paf-mvp-frontend/src/containers/welcome-widget/WelcomeWidget.tsx
@@ -17,6 +17,7 @@ import { Refresh } from '../../components/svg/refresh/Refresh';
 import { DotTyping } from '../../components/animations/DotTyping';
 import { OnekeyLogo } from '../../components/svg/onekey-logo/OnekeyLogo';
 import { currentScript } from '@frontend/utils/current-script';
+import { Window } from '@frontend/global';
 
 export interface IWelcomeWidgetProps {
   brandName?: string;
@@ -27,7 +28,7 @@ export interface IWelcomeWidgetProps {
 export const WelcomeWidget = ({ emitConsent }: IWelcomeWidgetProps) => {
   const [isOpen, setIsOpen] = useState(true);
   const [isDetailsPanelOpen, setIsDetailsPanelOpen] = useState(false);
-  const originalData = window.PAF.getIdsAndPreferences();
+  const originalData = (window as Window).PAF.getIdsAndPreferences();
 
   const originalIdentifier = originalData?.identifiers?.[0];
   const originalConsent = originalData?.preferences?.data?.use_browsing_for_personalization;
@@ -54,7 +55,7 @@ export const WelcomeWidget = ({ emitConsent }: IWelcomeWidgetProps) => {
 
   const updateIdentifier = async () => {
     setAppIdentifier(undefined);
-    const newIdentifier = await window.PAF.getNewId({ proxyHostName: pafClientNodeHost });
+    const newIdentifier = await (window as Window).PAF.getNewId({ proxyHostName: pafClientNodeHost });
     setAppIdentifier(newIdentifier);
   };
 
@@ -62,7 +63,7 @@ export const WelcomeWidget = ({ emitConsent }: IWelcomeWidgetProps) => {
     // Remove previous PAF id from the list
     const identifiers = (originalData?.identifiers ?? []).filter((id) => id.type !== 'paf_browser_id');
     identifiers.push(appIdentifier);
-    await window.PAF.updateIdsAndPreferences(pafClientNodeHost, consent, identifiers);
+    await (window as Window).PAF.updateIdsAndPreferences(pafClientNodeHost, consent, identifiers);
     closeWidget();
   };
 

--- a/paf-mvp-frontend/src/global.d.ts
+++ b/paf-mvp-frontend/src/global.d.ts
@@ -12,8 +12,8 @@ import {
 import { NotificationEnum } from './enums/notification.enum';
 import { ICommandProcessor } from './utils/queue';
 
-declare global {
-  interface Window {
+export type Window = WindowProxy &
+  typeof globalThis & {
     PAF: {
       queue?: ICommandProcessor;
       getNewId: typeof getNewId;
@@ -30,7 +30,4 @@ declare global {
       promptConsent: () => Promise<boolean>;
       showNotification: (notificationType: NotificationEnum) => void;
     };
-  }
-}
-
-export {};
+  };

--- a/paf-mvp-frontend/src/lib/paf-lib.ts
+++ b/paf-mvp-frontend/src/lib/paf-lib.ts
@@ -27,7 +27,7 @@ import { Log } from '@core/log';
 import { buildAuditLog } from '@core/model/audit-log';
 import { mapAdUnitCodeToDivId } from '../utils/ad-unit-code';
 import { setUpImmediateProcessingQueue } from '../utils/queue';
-import {} from '../global';
+import { Window } from '../global';
 
 // TODO: avoid global declaration
 declare const PAFUI: {
@@ -768,4 +768,4 @@ export const deleteIdsAndPreferences = (_option: DeleteIdsAndPreferencesOptions)
 };
 
 // Set up the queue of asynchronous commands
-setUpImmediateProcessingQueue(window.PAF);
+setUpImmediateProcessingQueue((<Window>window).PAF);

--- a/paf-mvp-frontend/src/main.ts
+++ b/paf-mvp-frontend/src/main.ts
@@ -15,17 +15,16 @@ import {
   signPreferences,
   updateIdsAndPreferences,
 } from './lib/paf-lib';
-import {} from './utils/queue';
+import { Window } from './global';
 
 currentScript.setScript(document.currentScript as HTMLScriptElement);
 
 const promptConsent = () => new Promise<boolean>((resolve) => new PromptConsent({ emitConsent: resolve }).render());
 const showNotification = (type: NotificationEnum) => notificationService.showNotification(type);
 
-// TODO: avoid global declaration
-window.PAFUI ??= { promptConsent, showNotification };
-window.PAF = {
-  ...(window.PAF ?? {}),
+(<Window>window).PAFUI ??= { promptConsent, showNotification };
+(<Window>window).PAF = {
+  ...((<Window>window).PAF ?? {}),
   // The rest has to be the official methods, should not be overridden from the outside
   getNewId,
   signPreferences,

--- a/paf-mvp-frontend/src/utils/queue.ts
+++ b/paf-mvp-frontend/src/utils/queue.ts
@@ -59,6 +59,8 @@ export const setUpImmediateProcessingQueue = (container: IQueueContainer): void 
   container.queue = processor;
 };
 
+const log = new Log('PAF', '#3bb8c3');
+
 class ImmediateProcessingQueue implements IProcessingQueue {
   push(...ops: Command[]): void {
     if (ops === undefined) {
@@ -76,5 +78,3 @@ class ImmediateProcessingQueue implements IProcessingQueue {
     }
   }
 }
-
-const log = new Log('PAF', '#3bb8c3');


### PR DESCRIPTION
- export Window interface in global
- import it paf-lib

=> this way the import is not seen as "unused" and will not be removed by optimization tools (ex: WebStorm)