### PR TITLE
Fix audit log not being displayed

### DIFF
--- a/paf-mvp-audit/src/model.ts
+++ b/paf-mvp-audit/src/model.ts
@@ -42,6 +42,6 @@ export class Model implements IModel {
    * Calls the refresh method on all the fields in the model to connect them to the currently displayed UI.
    */
   public updateUI() {
-    this.allFields.forEach((f) => f.updateUI());
+    this.allFields?.forEach((f) => f.updateUI());
   }
 }


### PR DESCRIPTION
Quick fix to restore the audit log in the demo.

The error in the console was the following

```
audit MESSAGE: check div-1
audit MESSAGE: adding div-1

model.ts:46 Uncaught TypeError: Cannot read properties of undefined (reading 'forEach')
    at n.updateUI (model.ts:46:20)
    at i.set value [as value] (fields.ts:182:16)
    at i.reset (fields.ts:222:10)
    at new constructor (fields.ts:131:10)
    at new i (locale.ts:49:20)
    at new n (model.ts:36:25)
    at new l (controller.ts:50:18)
    at main.ts:20:9
```

Audit's Model constructor:
- constructs FieldTransmissionResult
- store those created fields in the results variable

Though when a FieldTransmissionResult is constructed, the field
is reset, which calls model.updateUI().

updateUI() uses the results variable, but it's undefined until
all the fields have been constructed, hence the error.