### PR TITLE
Fix CMP close button clearing preferences

### DIFF
--- a/paf-mvp-cmp/src/controller.ts
+++ b/paf-mvp-cmp/src/controller.ts
@@ -375,6 +375,9 @@ export class Controller {
       case 'refuseAll':
         this.actionRefuseAll().catch((e) => this.log.Error(e));
         break;
+      case 'closeSettings':
+        this.actionCloseSettings().catch((e) => this.log.Error(e));
+        break;
       default:
         throw `Action '${action}' is not known`;
     }
@@ -397,6 +400,19 @@ export class Controller {
     this.model.status = PafStatus.NOT_PARTICIPATING;
     this.model.setFromIdsAndPreferences(undefined);
     this.display('snackbar');
+  }
+
+  /**
+   * Calls refuseAll if there are no preferences set, then close the modal.
+   * Closing the modal the first time, without having selected preferences, means not participating.
+   */
+  private async actionCloseSettings() {
+    if (this.model.status === null || this.model.status === PafStatus.UNKNOWN) {
+      await this.actionRefuseAll();
+    } else {
+      this.stopSnackbarHide();
+      this.view.hidePopup();
+    }
   }
 
   /**

--- a/paf-mvp-cmp/src/html/cards/settings.html
+++ b/paf-mvp-cmp/src/html/cards/settings.html
@@ -3,7 +3,7 @@
     <header class="ok-ui-card__header">
       <div class="ok-ui-card__actions">
         <a href="#" data-card="about" class="ok-ui-card__header-logo">${ _.Logo }</a>
-        <button type="button" class="ok-ui-button ok-ui-button--text ok-ui-button--icon-end" data-action="refuseAll">
+        <button type="button" class="ok-ui-button ok-ui-button--text ok-ui-button--icon-end" data-action="closeSettings">
           <svg width="0.667em" height="0.667em" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path
               d="M6.39332 0.666748L3.99999 3.06008L1.60666 0.666748L0.666656 1.60675L3.05999 4.00008L0.666656 6.39341L1.60666 7.33341L3.99999 4.94008L6.39332 7.33341L7.33332 6.39341L4.93999 4.00008L7.33332 1.60675L6.39332 0.666748Z"


### PR DESCRIPTION
The Cancel button of the modal was bound on the refuseAll action.
But it's true only the first time: when the user didn't select any
preferences. Afterwards, the cancel button should never call the
refuseAll action.