### PR TITLE
Fix "paf-proxy" error on publisher website

### DIFF
--- a/paf-mvp-demo-express/src/views/publisher/index.hbs
+++ b/paf-mvp-demo-express/src/views/publisher/index.hbs
@@ -863,7 +863,7 @@
                     document.querySelector('#preferences')
                       .addEventListener('click', (e) => {
                         e.preventDefault();
-                        PAF.refreshIdsAndPreferences({ proxyHostName: "{{proxyHostName}}", showPrompt: 'doPrompt'});
+                        PAF.refreshIdsAndPreferences({ proxyHostName: "{{pafNodeHost}}", showPrompt: 'doPrompt'});
                       });
                   </script>
                 </div>


### PR DESCRIPTION
Due to incorrect templating for proxy hostname