### PR TITLE
In demo page, ensure we can see some criteo ads

### DIFF
--- a/paf-mvp-demo-express/src/views/publisher/index.hbs
+++ b/paf-mvp-demo-express/src/views/publisher/index.hbs
@@ -49,7 +49,7 @@
                         delDomain: 'sademo-d.openx.net',
                         unit: '540096529',
                         test: true,
-                        customFloor: 0.1
+                        customFloor: 0.01
                     }
                 },
                 {
@@ -113,6 +113,7 @@
                         }
                     }
                 },
+                priceGranularity: 'high',
                 debug: true,
                 realTimeData: {
                     auctionDelay: 1000,


### PR DESCRIPTION
- Enable the priceGranularity to high [1] in order to have bids with
  low cpms
- Set the openx bid amount for div-1 to 0.01

This will enable us to have, at least for div-1, ads displayed by criteo
as long as the cpm is > 0.01.

[1] https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-Price-Granularity