### PR TITLE
Set Cross-Origin-Resource-Policy header on publisher websites

### DIFF
--- a/paf-mvp-demo-express/src/websites/paf-publisher.ts
+++ b/paf-mvp-demo-express/src/websites/paf-publisher.ts
@@ -22,6 +22,9 @@ pafPublisherWebSiteApp.expressApp.get(anythingButAssets, (req, res) => {
 
   // Send full URL in referer header, for testing this config
   res.setHeader('Referrer-Policy', 'unsafe-url');
+
+  // Allow resources from other origins to avoid error NotSameOriginAfterDefaultedToSameOriginByCoep when loading external resources
+  res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
 });
 
 export const pafPublisherCdnApp = new VHostApp(name, cdnHost);

--- a/paf-mvp-demo-express/src/websites/pif-publisher.ts
+++ b/paf-mvp-demo-express/src/websites/pif-publisher.ts
@@ -19,6 +19,9 @@ pifPublisherWebSiteApp.expressApp.get(anythingButAssets, (req, res) => {
     pafNodeHost,
     useCmpUI: true,
   });
+
+  // Allow resources from other origins to avoid error NotSameOriginAfterDefaultedToSameOriginByCoep when loading external resources
+  res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
 });
 
 export const pifPublisherCdnApp = new VHostApp(name, cdnHost);

--- a/paf-mvp-demo-express/src/websites/pof-publisher.ts
+++ b/paf-mvp-demo-express/src/websites/pof-publisher.ts
@@ -19,6 +19,9 @@ pofPublisherWebSiteApp.expressApp.get(anythingButAssets, (req, res) => {
     pafNodeHost,
     useCmpUI: true,
   });
+
+  // Allow resources from other origins to avoid error NotSameOriginAfterDefaultedToSameOriginByCoep when loading external resources
+  res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
 });
 
 export const pofPublisherCdnApp = new VHostApp(name, cdnHost);


### PR DESCRIPTION
To avoid errors `NotSameOriginAfterDefaultedToSameOriginByCoep`