### PR TITLE
Exclude PIF advertiser and publisher clients from startup on production.

### DIFF
--- a/paf-mvp-demo-express/README.md
+++ b/paf-mvp-demo-express/README.md
@@ -39,23 +39,16 @@ flowchart TB
 
 The demo is currently made of a set of websites accessible to anyone.
 
-- 3 fake publisher websites:
-  - [PIF publisher](https://www.pifdemopublisher.com/)
-  - [PAF publisher](https://www.pafdemopublisher.com/)
-  - [POF publisher](https://www.pofdemopublisher.com/)
 - 3 fake advertiser websites:
-  - [PIF advertiser](https://www.pifmarket.shop/)
-  - [PAF advertiser](https://www.pafmarket.shop/)
-  - [POF advertiser](https://www.pofmarket.shop/)
-
-Note: all sites can be accessed on the "root url"
-(ex: [https://www.pafdemopublisher.com/](https://www.pafdemopublisher.com/))
-or on any sub-path (ex: [https://www.pafdemopublisher.com/some-page/under-path?with-query-string=something](https://www.pafdemopublisher.com/some-page/under-path?with-query-string=something)).
-All pages will look exactly the same, but this can be the opportunity to test the solution under different circumstances.
-
-What makes a difference between these two types of websites is related to **first visits** and in particular how **unknown users** are handled:
-- publisher websites will ask for consent before anything
-- advertiser websites will only query OneKey: if the user is recognized, preferences are stored and a notification snackbar is displayed. Otherwise, the user is considered opt out.
+    - [PAF advertiser](https://www.pafmarket.shop/)
+    - [POF advertiser](https://www.pofmarket.shop/)
+    - [PIF advertiser](https://www.pifmarket.shop/)
+- advertiser websites only gather user consent
+- 3 fake publisher websites:
+    - [PAF publisher](https://www.pafdemopublisher.com/)
+    - [POF publisher](https://www.pofdemopublisher.com/)
+    - [PIF publisher](https://www.pifdemopublisher.com/)
+- publisher websites trigger **ad display** through PrebidJS
 
 A typical demo scenario would be to:
 - visit a publisher website first, notice the "first visit" UI and **define your marketing preferences**
@@ -67,6 +60,11 @@ A typical demo scenario would be to:
 - wait ONE minute (this is the "refresh frequency" on this demo)
 - refresh a website that has been visited already: the notification snackbar should be displayed
 
+Note: all sites can be accessed on the "root url"
+(ex: [https://www.pafdemopublisher.com/](https://www.pafdemopublisher.com/))
+or on any sub-path (ex: [https://www.pafdemopublisher.com/some-page/under-path?with-query-string=something](https://www.pafdemopublisher.com/some-page/under-path?with-query-string=something)).
+All pages will look exactly the same, but this can be the opportunity to test the solution under different circumstances.
+
 Of course this scenario can be run **with or without support of 3d party cookies** to demonstrate different sync mechanism (JS calls or full-page redirects)
 
 Finally, a "backoffice" [portal](http://portal.onekey.network/) is available to display the current ids and preferences on OneKey domain and easily reset it.
@@ -75,6 +73,10 @@ This component is not meant for end users.
 You might also want to delete the `paf_*` cookies from some websites to simulate a first visit to the website.
 
 ## Local installation
+
+⚠️ While most demo websites rely on OneKey **clients** hosted by the same web server instance,
+PIF publisher and PIF advertiser use OneKey clients hosted by Criteo on another web server instance.
+_When running the demo locally_, these clients are started in the same instance, so the demo is "self-sufficient".
 
 To install and run the demo project locally, follow these instructions:
 

--- a/paf-mvp-demo-express/src/apps.ts
+++ b/paf-mvp-demo-express/src/apps.ts
@@ -8,7 +8,7 @@ import { pafMarketCdnApp, pafMarketWebSiteApp } from './websites/paf-market';
 import { pifMarketCdnApp, pifMarketWebSiteApp } from './websites/pif-market';
 import { pofMarketCdnApp, pofMarketWebSiteApp } from './websites/pof-market';
 import { portalWebSiteApp } from './websites/portal';
-import { s2sOptions } from './demo-utils';
+import { isRunningOnDeveloperPC, s2sOptions } from './demo-utils';
 
 export const getAppsAndNodes = async (): Promise<{
   operators: OperatorNode[];
@@ -39,16 +39,24 @@ export const getAppsAndNodes = async (): Promise<{
     await OperatorNode.fromConfig('configs/crto-poc-1-operator/config.json', s2sOptions),
   ];
 
+  const clientConfigFiles = [
+    'configs/pafmarket-client/config.json',
+    'configs/pofmarket-client/config.json',
+    'configs/pafpublisher-client/config.json',
+    'configs/pofpublisher-client/config.json',
+    'configs/portal-client/config.json',
+  ];
+
+  /**
+   * On production, PIF advertiser and PIF publisher use clients hosted by Criteo, so they must not start on this instance.
+   * On local development, to keep things simple the clients are started on the same instance.
+   */
+  if (isRunningOnDeveloperPC) {
+    clientConfigFiles.push(...['configs/pifmarket-client/config.json', 'configs/pifpublisher-client/config.json']);
+  }
+
   const clientNodes: ClientNode[] = await Promise.all(
-    [
-      'configs/pifmarket-client/config.json',
-      'configs/pafmarket-client/config.json',
-      'configs/pofmarket-client/config.json',
-      'configs/pifpublisher-client/config.json',
-      'configs/pafpublisher-client/config.json',
-      'configs/pofpublisher-client/config.json',
-      'configs/portal-client/config.json',
-    ].map((path) => ClientNode.fromConfig(path, s2sOptions))
+    clientConfigFiles.map((path) => ClientNode.fromConfig(path, s2sOptions))
   );
 
   return { websites, cdns, operators, clientNodes };

--- a/paf-mvp-demo-express/src/demo-utils.ts
+++ b/paf-mvp-demo-express/src/demo-utils.ts
@@ -12,13 +12,13 @@ const relative = (path: string) => join(__dirname, path);
 export const keyPath = relative('../paf.key');
 export const crtPath = relative('../paf.crt');
 
-export const isLocalDev = fs.existsSync(keyPath) && fs.existsSync(crtPath);
+export const isRunningOnDeveloperPC = fs.existsSync(keyPath) && fs.existsSync(crtPath);
 
 export let sslOptions: { key: Buffer; cert: Buffer; passphrase: string };
 
 export const s2sOptions: AxiosRequestConfig = {};
 
-if (isLocalDev) {
+if (isRunningOnDeveloperPC) {
   sslOptions = {
     key: readFileSync(keyPath),
     cert: readFileSync(crtPath),

--- a/paf-mvp-demo-express/src/index.ts
+++ b/paf-mvp-demo-express/src/index.ts
@@ -1,7 +1,7 @@
 import express, { Express } from 'express';
 import { join } from 'path';
 import { createServer } from 'https';
-import { isLocalDev, sslOptions } from './demo-utils';
+import { isRunningOnDeveloperPC, sslOptions } from './demo-utils';
 import { create } from 'express-handlebars';
 import { MainApp, VHostApp } from '@core/express/express-apps';
 import { getAppsAndNodes } from './apps';
@@ -66,7 +66,7 @@ const relative = (dir: string) => join(__dirname, dir);
     for (const app of allApps) {
       console.log(`${app.hostName} (${app.name})`);
     }
-    if (isLocalDev) {
+    if (isRunningOnDeveloperPC) {
       console.log('');
       console.log('Make sure you have added these lines to your /etc/hosts file or equivalent:');
       for (const app of allApps) {
@@ -76,7 +76,7 @@ const relative = (dir: string) => join(__dirname, dir);
   });
 
   // Only start HTTPS on local dev: on prod, the HTTPS layer is handled by a proxy
-  if (isLocalDev) {
+  if (isRunningOnDeveloperPC) {
     console.log('Local dev: starting HTTPs (443) server');
     createServer(sslOptions, mainApp.expressApp).listen(443);
   }


### PR DESCRIPTION
These clients are now hosted by Criteo on a different VM.
Locally, the clients will remain so that the demo is "self-sufficient" when tested locally.