### PR TITLE
CMP: Fix notification snackbar

### DIFF
--- a/paf-mvp-cmp/src/main.ts
+++ b/paf-mvp-cmp/src/main.ts
@@ -34,8 +34,8 @@ const promptConsent = () =>
 const showNotification = (type: NotificationEnum) =>
   new Promise<void>((resolve) => {
     if (controller !== null) {
-      // TODO why is this triggering a "display of settings"??
-      controller.display('settings'); // TODO should use the notification type
+      // Show notification snack bar
+      controller.display('snackbar');
     }
     resolve();
   });


### PR DESCRIPTION
- do not show notification when landing on a site and cookies don't change
- show notification when modifying preferences and 3PC are supported (no redirect)