### PR TITLE
Make local refresh TTL parameterized

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14578,6 +14578,12 @@
         "next-tick": "1"
       }
     },
+    "node_modules/tinyduration": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.2.2.tgz",
+      "integrity": "sha512-eH6D0KIA4Xxje3ZRUnbsWfN28pAgTx3ZFQvgb0w9u8p9lxSX0eloxi4w165gv03GnvduR9m5JhToPxXvADHe+w==",
+      "dev": true
+    },
     "node_modules/tld-extract": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/tld-extract/-/tld-extract-2.0.1.tgz",
@@ -26775,6 +26781,12 @@
         "es5-ext": "~0.10.46",
         "next-tick": "1"
       }
+    },
+    "tinyduration": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.2.2.tgz",
+      "integrity": "sha512-eH6D0KIA4Xxje3ZRUnbsWfN28pAgTx3ZFQvgb0w9u8p9lxSX0eloxi4w165gv03GnvduR9m5JhToPxXvADHe+w==",
+      "dev": true
     },
     "tld-extract": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ua-parser-js": "^1.0.2",
     "uuid": "^8.3.2",
     "vhost": "^3.0.2",
+    "tinyduration": "^3.2.2",
     "winston": "^3.4.0"
   },
   "devDependencies": {

--- a/paf-mvp-core-js/src/cookies.ts
+++ b/paf-mvp-core-js/src/cookies.ts
@@ -14,12 +14,6 @@ export const getPrebidDataCacheExpiration = (date: Date = new Date()) => {
   expirationDate.setMonth(expirationDate.getMonth() + monthsCount);
   return expirationDate;
 };
-
-export const getPafRefreshExpiration = () => {
-  const minutesCount = 1;
-  return new Date(Date.now() + 1000 * 60 * minutesCount);
-};
-
 /**
  * Parse string cookie values and build an IdsAndOptionalPreferences accordingly
  * @param idsCookie

--- a/paf-mvp-demo-express/src/views/advertiser/index.hbs
+++ b/paf-mvp-demo-express/src/views/advertiser/index.hbs
@@ -30,7 +30,7 @@
 
 <!-- CMP -->
 <!-- See paf-mvp-cmp/README.md for details -->
-<script src="https://{{cdnHost}}/assets/paf-lib.js" data-client-hostname="{{pafNodeHost}}"></script>
+<script src="https://{{cdnHost}}/assets/paf-lib.js" data-client-hostname="{{pafNodeHost}}" data-cookie-ttl="PT30S"></script>
 <script src="https://{{cdnHost}}/assets/cmp/ok-ui.min.js"
     data-display-intro="false"
     data-snackbar-timeout-ms="5000"

--- a/paf-mvp-demo-express/src/views/publisher/index.hbs
+++ b/paf-mvp-demo-express/src/views/publisher/index.hbs
@@ -204,7 +204,7 @@
 
 <!-- CMP -->
 <!-- See paf-mvp-cmp/README.md for details -->
-<script src="https://{{cdnHost}}/assets/paf-lib.js" data-client-hostname="{{pafNodeHost}}"></script>
+<script src="https://{{cdnHost}}/assets/paf-lib.js" data-client-hostname="{{pafNodeHost}}" data-cookie-ttl="PT30S"></script>
 <script src="https://{{cdnHost}}/assets/cmp/ok-ui.min.js"
     data-display-intro="false"
     data-snackbar-timeout-ms="5000"

--- a/paf-mvp-frontend/index.html
+++ b/paf-mvp-frontend/index.html
@@ -44,7 +44,7 @@
   </style>
 </head>
 <body>
-<script src="/dist/paf-lib.js" data-client-hostname='cypress.client'></script>
+<script src="/dist/paf-lib.js" data-client-hostname='cypress.client' data-cookie-ttl="PT30S"></script>
 <script src="/dist/app.bundle.js"></script>
 </body>
 </html>

--- a/paf-mvp-frontend/package-lock.json
+++ b/paf-mvp-frontend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "preact": "^10.5.15",
         "rollup-plugin-sourcemaps": "^0.6.3",
+        "tinyduration": "^3.2.2",
         "ua-parser-js": "^1.0.2"
       },
       "devDependencies": {
@@ -10687,6 +10688,11 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "node_modules/tinyduration": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.2.2.tgz",
+      "integrity": "sha512-eH6D0KIA4Xxje3ZRUnbsWfN28pAgTx3ZFQvgb0w9u8p9lxSX0eloxi4w165gv03GnvduR9m5JhToPxXvADHe+w=="
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -19415,6 +19421,11 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "tinyduration": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.2.2.tgz",
+      "integrity": "sha512-eH6D0KIA4Xxje3ZRUnbsWfN28pAgTx3ZFQvgb0w9u8p9lxSX0eloxi4w165gv03GnvduR9m5JhToPxXvADHe+w=="
     },
     "tmp": {
       "version": "0.2.1",

--- a/paf-mvp-frontend/package.json
+++ b/paf-mvp-frontend/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "preact": "^10.5.15",
     "rollup-plugin-sourcemaps": "^0.6.3",
+    "tinyduration": "^3.2.2",
     "ua-parser-js": "^1.0.2"
   },
   "devDependencies": {

--- a/paf-mvp-frontend/src/lib/one-key.ts
+++ b/paf-mvp-frontend/src/lib/one-key.ts
@@ -9,7 +9,7 @@ import { auditLogStorageService } from '@frontend/services/audit-log-storage.ser
 import { seedStorageService } from '@frontend/services/seed-storage.service';
 
 // Get properties from HTML
-const pafLibScript = new CurrentScript<{ clientHostname: string; upFrontRedirect?: string }>();
+const pafLibScript = new CurrentScript<{ clientHostname: string; upFrontRedirect?: string; cookieTtl?: string }>();
 pafLibScript.setScript(document.currentScript);
 
 const triggerRedirectIfNeeded =
@@ -18,7 +18,8 @@ export const oneKeyLib = new OneKeyLib(
   pafLibScript.getData()?.clientHostname,
   triggerRedirectIfNeeded,
   auditLogStorageService,
-  seedStorageService
+  seedStorageService,
+  pafLibScript.getData()?.cookieTtl
 );
 
 const queue = (<Window>window).OneKey?.queue ?? [];

--- a/paf-mvp-frontend/src/lib/paf-lib.ts
+++ b/paf-mvp-frontend/src/lib/paf-lib.ts
@@ -25,8 +25,8 @@ import {
 import { NotificationEnum } from '@frontend/enums/notification.enum';
 import { Log } from '@core/log';
 import { EventHandler } from '@frontend/utils/event-handler';
-import { Cookies, getPafRefreshExpiration, getPrebidDataCacheExpiration, typedCookie } from '@core/cookies';
-import { getCookieValue } from '@frontend/utils/cookie';
+import { Cookies, getPrebidDataCacheExpiration, typedCookie } from '@core/cookies';
+import { DEFAULT_TTL_IN_SECONDS, getCookieValue, MAXIMUM_TTL_IN_SECONDS } from '@frontend/utils/cookie';
 import { QSParam } from '@core/query-string';
 import { jsonProxyEndpoints, proxyUriParams, redirectProxyEndpoints } from '@core/endpoints';
 import { isBrowserKnownToSupport3PC } from '@core/user-agent';
@@ -35,6 +35,7 @@ import { mapAdUnitCodeToDivId } from '@frontend/utils/ad-unit-code';
 import { buildAuditLog, findTransactionPath } from '@core/model/audit-log';
 import { IAuditLogStorageService } from '@frontend/services/audit-log-storage.service';
 import { ISeedStorageService } from '@frontend/services/seed-storage.service';
+import { parseDuration } from '@frontend/utils/date-utils';
 
 // TODO ------------------------------------------------------ move to one-key-lib.ts START
 export class OneKeyLib implements IOneKeyLib {
@@ -50,6 +51,8 @@ export class OneKeyLib implements IOneKeyLib {
   private thirdPartyCookiesSupported: boolean | undefined;
   private auditLogStorageService: IAuditLogStorageService;
   private seedStorageService: ISeedStorageService;
+  // cookie ttl in seconds
+  private readonly cookieTTL: number;
 
   unpersistedIds?: Identifier[];
 
@@ -57,12 +60,14 @@ export class OneKeyLib implements IOneKeyLib {
     clientHostname: string,
     triggerRedirectIfNeeded = true,
     auditLogStorageService: IAuditLogStorageService,
-    seedStorageService: ISeedStorageService
+    seedStorageService: ISeedStorageService,
+    cookieTTL?: string
   ) {
     this.clientHostname = clientHostname;
     this.triggerRedirectIfNeeded = triggerRedirectIfNeeded;
     this.auditLogStorageService = auditLogStorageService;
     this.seedStorageService = seedStorageService;
+    this.cookieTTL = this.parseCookieTTL(cookieTTL);
   }
 
   private redirect(url: string): void {
@@ -73,6 +78,28 @@ export class OneKeyLib implements IOneKeyLib {
       this.redirecting = true;
       location.replace(url);
     }
+  }
+
+  parseCookieTTL(duration: string): number {
+    if (duration === undefined) {
+      this.log.Info(`No cookie ttl was specified! Using default value: ${DEFAULT_TTL_IN_SECONDS} seconds`);
+      return DEFAULT_TTL_IN_SECONDS;
+    }
+    const durationInSeconds = parseDuration(duration);
+    if (durationInSeconds === null) {
+      this.log.Warn(
+        `The provided cookie ttl "${duration}" is not a valid ISO 8601 string! Using default value: ${DEFAULT_TTL_IN_SECONDS} seconds`
+      );
+      return DEFAULT_TTL_IN_SECONDS;
+    }
+    if (durationInSeconds > MAXIMUM_TTL_IN_SECONDS) {
+      this.log.Warn(
+        `The provided cookie ttl "${duration}" is too big! using maximum allowed value: ${MAXIMUM_TTL_IN_SECONDS} seconds`
+      );
+      return MAXIMUM_TTL_IN_SECONDS;
+    }
+    this.log.Info(`Cookie ttl is set to ${durationInSeconds} seconds`);
+    return durationInSeconds;
   }
 
   // Note: we don't use Content-type JSON to avoid having to trigger OPTIONS pre-flight.
@@ -167,10 +194,14 @@ export class OneKeyLib implements IOneKeyLib {
 
     // TODO use different expiration if "not participating"
     this.setCookie(cookieName, valueToStore, getPrebidDataCacheExpiration());
-    this.setCookie(Cookies.lastRefresh, new Date().toISOString(), getPafRefreshExpiration());
+    this.setCookie(Cookies.lastRefresh, new Date().toISOString(), this.getPafRefreshExpiration());
 
     return valueToStore;
   }
+
+  private getPafRefreshExpiration = () => {
+    return new Date(Date.now() + 1000 * this.cookieTTL);
+  };
 
   /**
    * Sign new optin value and send it with ids to the operator for writing

--- a/paf-mvp-frontend/src/utils/cookie.ts
+++ b/paf-mvp-frontend/src/utils/cookie.ts
@@ -1,2 +1,8 @@
 export const getCookieValue = (name: string): string | undefined =>
   document.cookie.match(`(^|;)\\s*${name}\\s*=\\s*([^;]+)`)?.pop() || undefined;
+
+// default value : 24h
+export const DEFAULT_TTL_IN_SECONDS = 24 * 3600;
+
+// maximum value : 1 week
+export const MAXIMUM_TTL_IN_SECONDS = 7 * 24 * 3600;

--- a/paf-mvp-frontend/src/utils/date-utils.ts
+++ b/paf-mvp-frontend/src/utils/date-utils.ts
@@ -1,0 +1,41 @@
+import { parse } from 'tinyduration';
+import { Duration } from 'tinyduration/src';
+
+export const parseDuration = (isoString: string): number | null => {
+  try {
+    const duration = parse(isoString);
+    return durationToSeconds(duration);
+  } catch (e) {
+    return null;
+  }
+};
+
+const durationToSeconds = (duration: Duration): number | null => {
+  if (duration === null || duration.negative) {
+    // Negative values are not allowed
+    return null;
+  }
+  let durationInSeconds = 0;
+  if (duration.years) {
+    durationInSeconds += duration.years * 31536000;
+  }
+  if (duration.months) {
+    durationInSeconds += duration.months * 2628000;
+  }
+  if (duration.weeks) {
+    durationInSeconds += duration.weeks * 604800;
+  }
+  if (duration.days) {
+    durationInSeconds += duration.days * 86400;
+  }
+  if (duration.hours) {
+    durationInSeconds += duration.hours * 3600;
+  }
+  if (duration.minutes) {
+    durationInSeconds += duration.minutes * 60;
+  }
+  if (duration.seconds) {
+    durationInSeconds += duration.seconds;
+  }
+  return durationInSeconds;
+};

--- a/paf-mvp-frontend/tests/test-cases/date-utils.test.ts
+++ b/paf-mvp-frontend/tests/test-cases/date-utils.test.ts
@@ -1,0 +1,33 @@
+import { parseDuration } from '@frontend/utils/date-utils';
+
+describe('ISO-8601 duration parser', () => {
+  const invalid_inputs = [null, 'SOME_RANDOM_STRING', 'PTT1S', ''];
+  test.each(invalid_inputs)('should return null if the input is not a valid ISO-8601 string (%s)', (input) => {
+    expect(parseDuration(input)).toBeNull;
+  });
+
+  const valid_data = [
+    {
+      input: 'PT1S', // 1 second
+      expected_output: 1,
+    },
+    {
+      input: 'P1W3DT5H30M', // 1 week, 3 days, 5 hours & 30 minutes
+      expected_output: 883800,
+    },
+    {
+      input: 'P2Y3M1W2DT4H22M15S', // 2 years, 3 months, 1 week, 2 days, 4 hours, 22 minutes & 15 seconds
+      expected_output: 71749335,
+    },
+    {
+      input: 'P333Y51M', // Some big value : 333 years & 51 months
+      expected_output: 10635516000,
+    },
+  ];
+  test.each(valid_data)(
+    'should return the corresponding duration in seconds when the input is a valid ISO string ($input)',
+    (data) => {
+      expect(parseDuration(data.input)).toEqual(data.expected_output);
+    }
+  );
+});


### PR DESCRIPTION
- Makes it possible to configure a local cookie TTL using an **optional** **ISO-8601** duration string.
- Default value is set to **24h** and is used when no value is specified or when the specified one is mal formatted.
- An upper bound of **1 week** is used when the specified value is too big.