### PR TITLE
Add middlewares to validate request and permissions for the operator write endpoints

### DIFF
--- a/paf-mvp-client-express/src/client-node.ts
+++ b/paf-mvp-client-express/src/client-node.ts
@@ -5,7 +5,7 @@ import { jsonProxyEndpoints, redirectProxyEndpoints } from '@core/endpoints';
 import { Config, Node, parseConfig } from '@core/express';
 import { fromDataToObject } from '@core/query-string';
 import { AxiosRequestConfig } from 'axios';
-import { ClientNodeError, ClientNodeErrorType, OperatorError, OperatorErrorType } from '@core/errors';
+import { NodeError, NodeErrorType } from '@core/errors';
 
 import { PublicKeyProvider, PublicKeyStore } from '@core/crypto';
 import { IJsonValidator, JsonSchemaTypes, JsonValidator } from '@core/validation/json-validator';
@@ -183,8 +183,8 @@ export class ClientNode extends Node {
       res.send(url);
       next();
     } catch (e) {
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.UNKNOWN_ERROR,
+      const error: NodeError = {
+        type: NodeErrorType.UNKNOWN_ERROR,
         details: '',
       };
       res.status(400);
@@ -200,8 +200,8 @@ export class ClientNode extends Node {
       next();
     } catch (e) {
       this.logger.Error(jsonProxyEndpoints.write, e);
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.UNKNOWN_ERROR,
+      const error: NodeError = {
+        type: NodeErrorType.UNKNOWN_ERROR,
         details: '',
       };
       res.status(400);
@@ -217,8 +217,8 @@ export class ClientNode extends Node {
       next();
     } catch (e) {
       this.logger.Error(jsonProxyEndpoints.verify3PC, e);
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.UNKNOWN_ERROR,
+      const error: NodeError = {
+        type: NodeErrorType.UNKNOWN_ERROR,
         details: '',
       };
       res.status(400);
@@ -234,8 +234,8 @@ export class ClientNode extends Node {
       next();
     } catch (e) {
       this.logger.Error(jsonProxyEndpoints.newId, e);
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.UNKNOWN_ERROR,
+      const error: NodeError = {
+        type: NodeErrorType.UNKNOWN_ERROR,
         details: '',
       };
       res.status(400);
@@ -251,8 +251,8 @@ export class ClientNode extends Node {
       next();
     } catch (e) {
       this.logger.Error(jsonProxyEndpoints.delete, e);
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.UNKNOWN_ERROR,
+      const error: NodeError = {
+        type: NodeErrorType.UNKNOWN_ERROR,
         details: '',
       };
       res.status(400);
@@ -268,8 +268,8 @@ export class ClientNode extends Node {
       next();
     } catch (e) {
       this.logger.Error(redirectProxyEndpoints.read, e);
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.UNKNOWN_ERROR,
+      const error: NodeError = {
+        type: NodeErrorType.UNKNOWN_ERROR,
         details: '',
       };
       res.status(400);
@@ -286,8 +286,8 @@ export class ClientNode extends Node {
     } catch (e) {
       this.logger.Error(redirectProxyEndpoints.write, e);
       // FIXME more robust error handling: websites should not be broken in this case, do a redirect with empty data
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.UNKNOWN_ERROR,
+      const error: NodeError = {
+        type: NodeErrorType.UNKNOWN_ERROR,
         details: '',
       };
       res.status(400);
@@ -303,8 +303,8 @@ export class ClientNode extends Node {
       next();
     } catch (e) {
       this.logger.Error(redirectProxyEndpoints.delete, e);
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.UNKNOWN_ERROR,
+      const error: NodeError = {
+        type: NodeErrorType.UNKNOWN_ERROR,
         details: '',
       };
       res.status(400);
@@ -321,8 +321,8 @@ export class ClientNode extends Node {
     if (!hasResponse) {
       this.logger.Error(jsonProxyEndpoints.verifyRead, message.error);
       // FIXME do something smart in case of error
-      const error: OperatorError = {
-        type: OperatorErrorType.UNKNOWN_ERROR,
+      const error: NodeError = {
+        type: NodeErrorType.UNKNOWN_ERROR,
         details: message.error.message, // TODO should be improved
       };
       res.status(400);
@@ -335,8 +335,8 @@ export class ClientNode extends Node {
       const isResponseValid = this.client.verifyReadResponse(message.response);
       if (!isResponseValid) {
         // TODO [errors] finer error feedback
-        const error: ClientNodeError = {
-          type: ClientNodeErrorType.VERIFICATION_FAILED,
+        const error: NodeError = {
+          type: NodeErrorType.VERIFICATION_FAILED,
           details: '',
         };
         this.logger.Error(jsonProxyEndpoints.verifyRead, error);
@@ -350,8 +350,8 @@ export class ClientNode extends Node {
     } catch (e) {
       this.logger.Error(jsonProxyEndpoints.verifyRead, e);
       // FIXME finer error return
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.UNKNOWN_ERROR,
+      const error: NodeError = {
+        type: NodeErrorType.UNKNOWN_ERROR,
         details: '',
       };
       res.status(400);
@@ -368,8 +368,8 @@ export class ClientNode extends Node {
     } catch (e) {
       this.logger.Error(jsonProxyEndpoints.signPrefs, e);
       // FIXME finer error return
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.UNKNOWN_ERROR,
+      const error: NodeError = {
+        type: NodeErrorType.UNKNOWN_ERROR,
         details: '',
       };
       res.status(400);
@@ -388,8 +388,8 @@ export class ClientNode extends Node {
     } catch (e) {
       this.logger.Error(jsonProxyEndpoints.createSeed, e);
       // FIXME finer error return
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.UNKNOWN_ERROR,
+      const error: NodeError = {
+        type: NodeErrorType.UNKNOWN_ERROR,
         details: '',
       };
       res.status(400);

--- a/paf-mvp-client-express/src/website-identity-validator.ts
+++ b/paf-mvp-client-express/src/website-identity-validator.ts
@@ -1,7 +1,7 @@
 import cors, { CorsOptions } from 'cors';
 import { NextFunction, Request, Response } from 'express';
 import { escapeRegExp, getTopLevelDomain } from '@core/express';
-import { ClientNodeError, ClientNodeErrorType } from '@core/errors';
+import { NodeError, NodeErrorType } from '@core/errors';
 import { proxyUriParams } from '@core/endpoints';
 
 /**
@@ -54,8 +54,8 @@ export class WebsiteIdentityValidator {
     if (this.isValidWebsiteUrl(origin)) {
       next();
     } else {
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.INVALID_ORIGIN,
+      const error: NodeError = {
+        type: NodeErrorType.INVALID_ORIGIN,
         details: `Origin is not allowed: ${origin}`,
       };
       res.status(400);
@@ -73,8 +73,8 @@ export class WebsiteIdentityValidator {
     if (this.isValidWebsiteUrl(referer)) {
       next();
     } else {
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.INVALID_REFERER,
+      const error: NodeError = {
+        type: NodeErrorType.INVALID_REFERER,
         details: `Referer is not allowed: ${referer}`,
       };
       res.status(400);
@@ -92,8 +92,8 @@ export class WebsiteIdentityValidator {
     if (this.isValidWebsiteUrl(returnUrl)) {
       next();
     } else {
-      const error: ClientNodeError = {
-        type: ClientNodeErrorType.INVALID_RETURN_URL,
+      const error: NodeError = {
+        type: NodeErrorType.INVALID_RETURN_URL,
         details: `Invalid return URL: ${returnUrl}`,
       };
       res.status(400);

--- a/paf-mvp-core-js/src/errors.ts
+++ b/paf-mvp-core-js/src/errors.ts
@@ -1,26 +1,15 @@
-export enum ClientNodeErrorType {
+export enum NodeErrorType {
   INVALID_RETURN_URL = 'INVALID_RETURN_URL',
   VERIFICATION_FAILED = 'VERIFICATION_FAILED',
   UNKNOWN_ERROR = 'UNKNOWN_ERROR',
   INVALID_ORIGIN = 'INVALID_ORIGIN',
   INVALID_REFERER = 'INVALID_REFERER',
   INVALID_JSON_BODY = 'INVALID_JSON_BODY',
+  UNAUTHORIZED_OPERATION = 'UNAUTHORIZED_OPERATION',
+  INVALID_QUERY_STRING = 'INVALID_QUERY_STRING',
 }
 
-export interface ClientNodeError {
-  type: ClientNodeErrorType;
-  details: string;
-}
-
-export enum OperatorErrorType {
-  MISSING_PAF_PARAM = 'MISSING_PAF_PARAM',
-  INVALID_RETURN_URL = 'INVALID_RETURN_URL',
-  UNKNOWN_ERROR = 'UNKNOWN_ERROR',
-  INVALID_ORIGIN = 'INVALID_ORIGIN',
-  INVALID_REFERER = 'INVALID_REFERER',
-}
-
-export interface OperatorError {
-  type: OperatorErrorType;
+export interface NodeError {
+  type: NodeErrorType;
   details: string;
 }

--- a/paf-mvp-core-js/src/express/node.ts
+++ b/paf-mvp-core-js/src/express/node.ts
@@ -4,11 +4,13 @@ import { VHostApp } from '@core/express/express-apps';
 import { GetIdentityResponseBuilder } from '@core/model';
 import { participantEndpoints } from '@core/endpoints';
 import cors from 'cors';
-import { corsOptionsAcceptAll } from '@core/express/utils';
+import { corsOptionsAcceptAll, getPafDataFromQueryString, httpRedirect, isValidHttpUrl } from '@core/express/utils';
 import { IdentityConfig } from '@core/express/config';
-import { ClientNodeError, ClientNodeErrorType } from '@core/errors';
+import { NodeError, NodeErrorType } from '@core/errors';
 import { ErrorRequestHandler, NextFunction, Request, RequestHandler, Response } from 'express';
 import { IJsonValidator } from '@core/validation/json-validator';
+import { decodeBase64, QSParam } from '@core/query-string';
+import { RedirectRequest } from '@core/model/model';
 
 export interface INode {
   app: VHostApp;
@@ -85,31 +87,100 @@ export class Node implements INode {
   /**
    * Returns a handler that handles errors
    * @param endPointName
-   * @protected
    */
-  protected handleErrors(endPointName: string): ErrorRequestHandler {
-    return (err: ClientNodeError, req: Request, res: Response, next: NextFunction) => {
+  handleErrors(endPointName: string): ErrorRequestHandler {
+    return (err: NodeError, req: Request, res: Response, next: NextFunction) => {
       // TODO next step: define a common logging format for errors (on 1 line), usable for monitoring
       this.logger.Error(endPointName, err);
+      // For redirect endpoints, if the provided redirect url is invalid, try to redirect back to referer
+      if (err.type === NodeErrorType.INVALID_RETURN_URL) {
+        this.redirectToReferer(req, res, endPointName);
+      }
     };
   }
 
+  private redirectToReferer(req: Request, res: Response, endPointName: string) {
+    const referer = req.header('referer');
+    this.logger.Warn(endPointName, `Redirecting to referer: ${referer} ...`);
+    try {
+      const redirectUrl = new URL(referer);
+      httpRedirect(res, redirectUrl.toString());
+    } catch (e) {
+      this.logger.Error(endPointName, e);
+    }
+  }
+
   /**
-   * Build an handler that validate the body of the Request
+   * Build a handler that validates the body of the Request
    * against a JSON schema.
-   * @returns the built hander
+   * @returns the built handler
    */
-  protected buildJsonBodyValidatorHandler(jsonSchema: string): RequestHandler {
+  buildJsonBodyValidatorHandler(jsonSchema: string): RequestHandler {
     return (req: Request, res: Response, next: NextFunction) => {
       const validation = this.jsonValidator.validate(jsonSchema, req.body as string);
       if (!validation.isValid) {
         const details = validation.errors.map((e) => e.message).join(' - ');
-        const error: ClientNodeError = {
-          type: ClientNodeErrorType.INVALID_JSON_BODY,
+        const error: NodeError = {
+          type: NodeErrorType.INVALID_JSON_BODY,
           details,
         };
         res.status(400);
         res.json(error);
+        next(error);
+      } else {
+        next();
+      }
+    };
+  }
+
+  /**
+   * Builds a handler that validates the query string
+   * against a JSON schema.
+   * @returns the built handler
+   */
+  buildQueryStringValidatorHandler(jsonSchema: string): RequestHandler {
+    return (req: Request, res: Response, next: NextFunction) => {
+      const data = req.query[QSParam.paf] as string | undefined;
+      const decodedData = data ? decodeBase64(data) : undefined;
+      if (!decodedData) {
+        const error: NodeError = {
+          type: NodeErrorType.INVALID_QUERY_STRING,
+          details: `Received Query string: '${data}' is not a valid Base64 string`,
+        };
+        res.status(400);
+        res.json(error);
+        next(error);
+        return;
+      }
+      const validation = this.jsonValidator.validate(jsonSchema, decodedData);
+      if (!validation.isValid) {
+        const details = validation.errors.map((e) => e.message).join(' - ');
+        const error: NodeError = {
+          type: NodeErrorType.INVALID_QUERY_STRING,
+          details,
+        };
+        res.status(400);
+        res.json(error);
+        next(error);
+      } else {
+        next();
+      }
+    };
+  }
+  /**
+   * Builds and returns a handler that validates the specified return url for Redirect requests.
+   * @returns the built handler
+   */
+  returnUrlValidationHandler<T>(): RequestHandler {
+    return (req: Request, res: Response, next: NextFunction) => {
+      const request = getPafDataFromQueryString<RedirectRequest<T>>(req);
+      const returnUrl = request?.returnUrl;
+      // check if return url is a valid http/https url
+      if (!isValidHttpUrl(returnUrl)) {
+        const error: NodeError = {
+          type: NodeErrorType.INVALID_RETURN_URL,
+          details: `Specified returnUrl '${returnUrl}' is not a valid url`,
+        };
         next(error);
       } else {
         next();

--- a/paf-mvp-core-js/src/validation/json-validator.ts
+++ b/paf-mvp-core-js/src/validation/json-validator.ts
@@ -11,6 +11,8 @@ export type JsonSchemaType = string;
  */
 export abstract class JsonSchemaTypes {
   static createSeedRequest: JsonSchemaType = 'post-seed-request.json';
+  static writeIdAndPreferencesRestRequest: JsonSchemaType = 'post-ids-prefs-request.json';
+  static writeIdAndPreferencesRedirectRequest: JsonSchemaType = 'redirect-post-ids-prefs-request.json';
 }
 
 /**

--- a/paf-mvp-core-js/tests/test-cases/node.test.ts
+++ b/paf-mvp-core-js/tests/test-cases/node.test.ts
@@ -1,0 +1,196 @@
+import { IJsonValidator, JsonSchemaType, JsonValidation } from '@core/validation/json-validator';
+import { IdentityConfig, Node } from '@core/express';
+import { createRequest, createResponse, MockResponse } from 'node-mocks-http';
+import { NextFunction, Response } from 'express';
+import { NodeError, NodeErrorType } from '@core/errors';
+import { getTimeStampInSec } from '@core/timestamp';
+import { encodeBase64, QSParam } from '@core/query-string';
+
+const buildStaticJsonValidator = (validationResult: boolean): IJsonValidator => {
+  const jsonValidation: JsonValidation = {
+    isValid: validationResult,
+    value: {},
+    errors: validationResult ? [] : [new Error('error message from validator')],
+  };
+  return {
+    start: jest.fn(),
+    validate: jest.fn(() => jsonValidation),
+  };
+};
+const identity: IdentityConfig = {
+  type: 'operator',
+  // Name of the OneKey participant
+  name: 'Example operator',
+  // Current public key
+  publicKeys: [
+    {
+      // Timestamps are expressed in seconds
+      startTimestampInSec: getTimeStampInSec(new Date('2022-01-01T10:50:00.000Z')),
+      endTimestampInSec: getTimeStampInSec(new Date('2022-12-31T12:00:00.000Z')),
+      publicKey: '',
+    },
+  ],
+  // Email address of DPO
+  dpoEmailAddress: 'contact@example.onekey.network',
+  // URL of a privacy page
+  privacyPolicyUrl: new URL('https://example.onekey.network/privacy'),
+};
+const publicKeyProviderAlwaysOKMock = () => Promise.resolve({ verify: () => true });
+
+describe('Json body validator handler', () => {
+  let response: MockResponse<Response>;
+  let nextFunction: NextFunction;
+  const payload = { some_key: 'some_text' };
+  const request = createRequest({
+    method: 'POST',
+    body: payload,
+  });
+  beforeEach(() => {
+    response = createResponse();
+    nextFunction = jest.fn();
+  });
+
+  test('should pass an InvalidJsonBody error to the nextFunction if the validation of request body fails', () => {
+    const mockJsonValidatorAlwaysKO = buildStaticJsonValidator(false);
+    const validationSpy = jest.spyOn(mockJsonValidatorAlwaysKO, 'validate');
+    const node = new Node('MyNode', identity, mockJsonValidatorAlwaysKO, publicKeyProviderAlwaysOKMock);
+
+    node.buildJsonBodyValidatorHandler('jsonSchema')(request, response, nextFunction);
+
+    expect(validationSpy).toBeCalledWith('jsonSchema', payload);
+
+    const expectedError: NodeError = {
+      type: NodeErrorType.INVALID_JSON_BODY,
+      details: 'error message from validator',
+    };
+    expect(nextFunction).toBeCalledWith(expectedError);
+    expect(response._getStatusCode()).toEqual(400);
+  });
+
+  test('should call the nextFunction with no error when request body validation succeeds', () => {
+    const mockJsonValidatorAlwaysOK = buildStaticJsonValidator(true);
+    const validationSpy = jest.spyOn(mockJsonValidatorAlwaysOK, 'validate');
+    const node = new Node('MyNode', identity, mockJsonValidatorAlwaysOK, publicKeyProviderAlwaysOKMock);
+
+    node.buildJsonBodyValidatorHandler('jsonSchema')(request, response, nextFunction);
+
+    expect(validationSpy).toBeCalledWith('jsonSchema', payload);
+
+    expect(nextFunction).toBeCalledWith();
+    expect(response._getStatusCode()).toEqual(200);
+  });
+});
+
+describe('Query string validator handler', () => {
+  let response: MockResponse<Response>;
+  let nextFunction: NextFunction;
+
+  beforeEach(() => {
+    response = createResponse();
+    nextFunction = jest.fn();
+  });
+
+  const errorCases = [
+    {
+      queryString: undefined,
+      description: 'undefined',
+      expected_error: 'error message from validator',
+    },
+    {
+      queryString: '',
+      description: 'empty',
+      expected_error: "Received Query string: '' is not a valid Base64 string",
+    },
+    {
+      queryString: 'aGVsbG8gd29yZA==',
+      description: 'not a valid request',
+      expected_error: 'error message from validator',
+    },
+  ];
+  test.each(errorCases)(
+    'should pass an invalid query string error to the nextFunction when the query string is $description',
+    (input) => {
+      const mockJsonValidatorAlwaysKO = buildStaticJsonValidator(false);
+      const node = new Node('MyNode', identity, mockJsonValidatorAlwaysKO, publicKeyProviderAlwaysOKMock);
+      const targetUrl = new URL('https://somedomain.com');
+      targetUrl.searchParams.set(QSParam.paf, input.queryString);
+      const request = createRequest({
+        method: 'GET',
+        url: targetUrl.toString(),
+      });
+      node.buildQueryStringValidatorHandler('jsonSchema')(request, response, nextFunction);
+      const expectedError: NodeError = {
+        type: NodeErrorType.INVALID_QUERY_STRING,
+        details: input.expected_error,
+      };
+      expect(nextFunction).toBeCalledWith(expectedError);
+      expect(response._getStatusCode()).toEqual(400);
+    }
+  );
+
+  test('should call the nextFunction with no error when query validation succeeds', () => {
+    const mockJsonValidatorAlwaysOK = buildStaticJsonValidator(true);
+    const node = new Node('MyNode', identity, mockJsonValidatorAlwaysOK, publicKeyProviderAlwaysOKMock);
+    const targetUrl = new URL('https://somedomain.com');
+    targetUrl.searchParams.set(QSParam.paf, 'sds');
+    const request = createRequest({
+      method: 'GET',
+      url: targetUrl.toString(),
+    });
+    node.buildQueryStringValidatorHandler('jsonSchema')(request, response, nextFunction);
+    expect(nextFunction).toBeCalledWith();
+    expect(response._getStatusCode()).toEqual(200);
+  });
+});
+
+describe('Return URL validation handler', () => {
+  let response: MockResponse<Response>;
+  let nextFunction: NextFunction;
+  const mockJsonValidatorAlwaysOK = buildStaticJsonValidator(true);
+  let targetUrl: URL;
+  const node = new Node('MyNode', identity, mockJsonValidatorAlwaysOK, publicKeyProviderAlwaysOKMock);
+
+  beforeEach(() => {
+    response = createResponse();
+    nextFunction = jest.fn();
+    targetUrl = new URL('https://somedomain.com');
+  });
+  const cases = [
+    {
+      returnUrl: '',
+      description: 'empty',
+    },
+    {
+      returnUrl: undefined,
+      description: 'undefined',
+    },
+    {
+      returnUrl: 'www.someurl.com',
+      description: 'not a valid http/https url',
+    },
+  ];
+  test.each(cases)(
+    'should pass an invalid return url error to the newtFunction when the redirectUrl is $description',
+    (input) => {
+      const queryString = encodeBase64(JSON.stringify({ returnUrl: input.returnUrl, request: {} }));
+      targetUrl.searchParams.set(QSParam.paf, queryString);
+      const request = createRequest({
+        method: 'GET',
+        url: targetUrl.toString(),
+      });
+      node.returnUrlValidationHandler()(request, response, nextFunction);
+      expect(nextFunction).toBeCalledWith(expect.objectContaining({ type: NodeErrorType.INVALID_RETURN_URL }));
+    }
+  );
+
+  test('should call the next function with no error if the provided redirectUrl is valid', () => {
+    const queryString = encodeBase64(JSON.stringify({ returnUrl: 'https://www.someurl.com', request: {} }));
+    targetUrl.searchParams.set(QSParam.paf, queryString);
+    const request = createRequest({
+      method: 'GET',
+      url: targetUrl.toString(),
+    });
+    node.returnUrlValidationHandler()(request, response, nextFunction);
+    expect(nextFunction).toBeCalledWith();
+  });
+});

--- a/paf-mvp-operator-express/tests/test-cases/operator-node-write.test.ts
+++ b/paf-mvp-operator-express/tests/test-cases/operator-node-write.test.ts
@@ -1,0 +1,73 @@
+import { OperatorNode } from '@operator/operator-node';
+import { createResponse, MockResponse } from 'node-mocks-http';
+import { NextFunction, Response } from 'express';
+import { OperatorUtils } from '../utils/operator-utils';
+import { NodeErrorType } from '@core/errors';
+
+describe('Write permission Handler', () => {
+  let response: MockResponse<Response>;
+  let nextFunction: NextFunction;
+  const operatorNode: OperatorNode = OperatorUtils.buildOperator(OperatorUtils.getUnsuccessfulJsonValidatorMock(), () =>
+    Promise.resolve({ verify: () => true })
+  );
+  beforeEach(() => {
+    response = createResponse();
+    nextFunction = jest.fn();
+  });
+  const failCases = [
+    {
+      request: OperatorUtils.generateMockPostIdsPrefRequest('', false),
+      description: 'the domain is empty (postRequest)',
+      isRedirect: false,
+    },
+    {
+      request: OperatorUtils.generateMockPostIdsPrefRequest('unknown domain', false),
+      description: 'the domain is unknown (postRequest)',
+      isRedirect: false,
+    },
+    {
+      request: OperatorUtils.generateMockPostIdsPrefRequest('paf.read-only.com', false),
+      description: 'the domain does not have the write permission (postRequest)',
+      isRedirect: false,
+    },
+    {
+      request: OperatorUtils.generateMockPostIdsPrefRequest('', true),
+      description: 'the domain is empty (redirectRequest)',
+      isRedirect: true,
+    },
+    {
+      request: OperatorUtils.generateMockPostIdsPrefRequest('unknown domain', true),
+      description: 'the domain is unknown (redirectRequest)',
+      isRedirect: true,
+    },
+    {
+      request: OperatorUtils.generateMockPostIdsPrefRequest('paf.read-only.com', true),
+      description: 'the domain does not have the write permission (redirectRequest)',
+      isRedirect: true,
+    },
+  ];
+
+  test.each(failCases)('Should pass an UNAUTHORIZED_OPERATION error to the nextFunction when $description', (input) => {
+    operatorNode.buildWritePermissionHandler(input.isRedirect)(input.request, response, nextFunction);
+    expect(nextFunction).toBeCalledWith(expect.objectContaining({ type: NodeErrorType.UNAUTHORIZED_OPERATION }));
+    expect(response._getStatusCode()).toEqual(400);
+  });
+
+  const successCases = [
+    {
+      request: OperatorUtils.generateMockPostIdsPrefRequest('paf.write-only.com', false),
+      description: 'the domain is authorized to write (postRequest)',
+      isRedirect: false,
+    },
+    {
+      request: OperatorUtils.generateMockPostIdsPrefRequest('paf.read-write.com', true),
+      description: 'the domain is authorized to write (redirectRequest)',
+      isRedirect: true,
+    },
+  ];
+  test.each(successCases)('Should call the nextFunction with no error  when $description', (input) => {
+    operatorNode.buildWritePermissionHandler(input.isRedirect)(input.request, response, nextFunction);
+    expect(nextFunction).toBeCalledWith();
+    expect(response._getStatusCode()).toEqual(200);
+  });
+});

--- a/paf-mvp-operator-express/tests/utils/operator-utils.ts
+++ b/paf-mvp-operator-express/tests/utils/operator-utils.ts
@@ -1,0 +1,113 @@
+import { IJsonValidator, JsonValidation } from '@core/validation/json-validator';
+import { PublicKeyProvider } from '@core/crypto';
+import { OperatorNode, Permission } from '@operator/operator-node';
+import { getTimeStampInSec } from '@core/timestamp';
+import { Domain, PostIdsPrefsRequest } from '@core/model';
+import { createRequest } from 'node-mocks-http';
+import { encodeBase64, QSParam } from '@core/query-string';
+
+export class OperatorUtils {
+  private static operatorPublicKey = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEiZIRhGxNdfG4l6LuY2Qfjyf60R0
+jmcW7W3x9wvlX4YXqJUQKR2c0lveqVDj4hwO0kTZDuNRUhgxk4irwV3fzw==
+-----END PUBLIC KEY-----`;
+
+  private static operatorHost = 'example.onekey.network';
+
+  private static operatorPrivateKey = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgxK7RQm5KP1g62SQn
+oyeE+rrDPJzpZxIyCCTHDvd1TRShRANCAAQSJkhGEbE118biXou5jZB+PJ/rRHSO
+ZxbtbfH3C+VfhheolRApHZzSW96pUOPiHA7SRNkO41FSGDGTiKvBXd/P
+-----END PRIVATE KEY-----`;
+
+  /**
+   * Builds an OperatorNode with specified jsonValidator and publicKeyProvider
+   * @param jsonValidator
+   * @param publicKeyProvider
+   * @returns the built OperatorNode
+   */
+  static buildOperator = (jsonValidator: IJsonValidator, publicKeyProvider: PublicKeyProvider): OperatorNode =>
+    new OperatorNode(
+      {
+        // Name of the OneKey participant
+        name: 'Example operator',
+        // Current public key
+        publicKeys: [
+          {
+            // Timestamps are expressed in seconds
+            startTimestampInSec: getTimeStampInSec(new Date('2022-01-01T10:50:00.000Z')),
+            endTimestampInSec: getTimeStampInSec(new Date('2022-12-31T12:00:00.000Z')),
+            publicKey: this.operatorPublicKey,
+          },
+        ],
+        // Email address of DPO
+        dpoEmailAddress: 'contact@example.onekey.network',
+        // URL of a privacy page
+        privacyPolicyUrl: new URL('https://example.onekey.network/privacy'),
+      },
+      // The operator host name to receive requests
+      this.operatorHost,
+      // Current private key
+      this.operatorPrivateKey,
+      // List of OneKey client node host names and their corresponding permissions
+      {
+        'paf.read-write.com': [Permission.READ, Permission.WRITE],
+        'paf.read-only.com': [Permission.READ],
+        'paf.write-only.com': [Permission.WRITE],
+      },
+      jsonValidator,
+      publicKeyProvider
+    );
+
+  private static buildStaticJsonValidator = (validationResult: boolean): IJsonValidator => {
+    const jsonValidation: JsonValidation = {
+      isValid: validationResult,
+      value: {},
+    };
+    return {
+      start: jest.fn(),
+      validate: jest.fn(() => jsonValidation),
+    };
+  };
+
+  /**
+   * @returns a jsonValidator that always succeed
+   */
+  static getSuccessfulJsonValidatorMock = (): IJsonValidator => this.buildStaticJsonValidator(true);
+
+  /**
+   * @returns a jsonValidator that always fail
+   */
+  static getUnsuccessfulJsonValidatorMock = (): IJsonValidator => this.buildStaticJsonValidator(false);
+
+  /**
+   * @returns a mock postIdsPrefRequest or redirectIdsPrefRequest with the specified sender domain
+   */
+  static generateMockPostIdsPrefRequest(domain: Domain, isRedirect: boolean) {
+    const postIdsPrefRequest: PostIdsPrefsRequest = {
+      sender: domain,
+      receiver: undefined,
+      timestamp: undefined,
+      signature: undefined,
+      body: undefined,
+    };
+    if (isRedirect) {
+      const targetUrl = new URL('https://somedomain.com');
+      const queryString = encodeBase64(
+        JSON.stringify({ returnUrl: 'https://someurl.com', request: postIdsPrefRequest })
+      );
+      targetUrl.searchParams.set(QSParam.paf, queryString);
+      return createRequest({
+        method: 'GET',
+        url: targetUrl.toString(),
+      });
+    } else {
+      const payload = JSON.stringify(postIdsPrefRequest);
+      const postRequest = createRequest({
+        method: 'POST',
+      });
+      postRequest.body = payload;
+      return postRequest;
+    }
+  }
+}


### PR DESCRIPTION
- Add a `PermissionHandler` for both post and redirect write endpoints
- Add a `RedirectUrlHandler` for the redirect write endpoint
- Add a `QueryStringValidationHandler` for redirect endpoints
- Add tests for `Node` and `OperatorNode`  